### PR TITLE
Release v1.2.0: PHP 8 / Magento 2.4+ parameters, output verbosity fixes, run_php_cs strategy

### DIFF
--- a/src/commands/download_tools.yml
+++ b/src/commands/download_tools.yml
@@ -24,7 +24,7 @@ steps:
       command: rm -rf app/code/Ebizmarts
   - run:
       name: Download magento Composer auth.json file
-      command: wget --quiet $MAGENTO_COMPOSER_AUTH
+      command: wget $MAGENTO_COMPOSER_AUTH
   - run:
       name: Set bin/magento as executable
       command: chmod +x bin/magento

--- a/src/commands/install_linux_dependencies.yml
+++ b/src/commands/install_linux_dependencies.yml
@@ -42,7 +42,7 @@ steps:
       command: echo 127.0.0.1 magento2.dev | sudo tee -a /etc/hosts
   - run:
       name: Download Magento 2 web server configuration file
-      command: wget --quiet $MAGENTO_WEB_SERVER_CONF
+      command: wget $MAGENTO_WEB_SERVER_CONF
   - run:
       name: Copy Magento 2 web server configuration file
       command: <<include(scripts/cp_apache_config.sh)>>

--- a/src/commands/install_linux_dependencies.yml
+++ b/src/commands/install_linux_dependencies.yml
@@ -8,6 +8,9 @@ parameters:
   libraries_to_install:
     type: string
     default: "libicu-dev libjpeg-dev libmcrypt-dev libpng-dev libwebp-dev libxml2-dev libxpm-dev libxslt-dev libz-dev libzip-dev zlib1g-dev"
+  gd_configure_flags:
+    type: string
+    default: "--with-png-dir=/usr/include --with-jpeg-dir=/usr/include"
 steps:
   - run:
       name: Update linux packages
@@ -22,6 +25,8 @@ steps:
       command: <<include(scripts/install_sys_libs.sh)>>
   - run:
       name: Configure PHP extensions
+      environment:
+        PARAM_GD_CONFIGURE_FLAGS: << parameters.gd_configure_flags >>
       command: <<include(scripts/config_php_exts.sh)>>
   - run:
       name: Install PHP extensions

--- a/src/commands/install_linux_dependencies.yml
+++ b/src/commands/install_linux_dependencies.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
   - run:
       name: Update linux packages
-      command: sudo apt-get update -qq || sudo apt-get update -qq
+      command: sudo apt-get update || sudo apt-get update
   - run:
       name: Set PHP Memory to 1G
       command: <<include(scripts/set_memory_limit_1g.sh)>>
@@ -36,7 +36,7 @@ steps:
       command: <<include(scripts/install_php_exts.sh)>>
   - run:
       name: Install MariaDB client
-      command: sudo apt-get install -qq -y mariadb-client
+      command: sudo apt-get install -y mariadb-client
   - run:
       name: Add magento2.dev to hosts file
       command: echo 127.0.0.1 magento2.dev | sudo tee -a /etc/hosts

--- a/src/commands/install_linux_dependencies.yml
+++ b/src/commands/install_linux_dependencies.yml
@@ -11,6 +11,9 @@ parameters:
   gd_configure_flags:
     type: string
     default: "--with-png-dir=/usr/include --with-jpeg-dir=/usr/include"
+  import_db:
+    type: boolean
+    default: true
 steps:
   - run:
       name: Update linux packages
@@ -51,6 +54,9 @@ steps:
   - run:
       name: Restart apache
       command: sudo service apache2 restart
-  - run:
-      name: Import database dump
-      command: <<include(scripts/import_db_dump.sh)>>
+  - when:
+      condition: << parameters.import_db >>
+      steps:
+        - run:
+            name: Import database dump
+            command: <<include(scripts/import_db_dump.sh)>>

--- a/src/commands/install_linux_dependencies.yml
+++ b/src/commands/install_linux_dependencies.yml
@@ -28,9 +28,7 @@ steps:
       command: <<include(scripts/install_sys_libs.sh)>>
   - run:
       name: Configure PHP extensions
-      environment:
-        PARAM_GD_CONFIGURE_FLAGS: << parameters.gd_configure_flags >>
-      command: <<include(scripts/config_php_exts.sh)>>
+      command: sudo -E docker-php-ext-configure intl && sudo -E docker-php-ext-configure gd << parameters.gd_configure_flags >>
   - run:
       name: Install PHP extensions
       environment:

--- a/src/commands/install_mariadb_and_setup_webserver.yml
+++ b/src/commands/install_mariadb_and_setup_webserver.yml
@@ -10,7 +10,7 @@ steps:
       command: echo 127.0.0.1 magento2.dev | sudo tee -a /etc/hosts
   - run:
       name: Download Magento 2 web server configuration file
-      command: wget --quiet $MAGENTO_WEB_SERVER_CONF
+      command: wget $MAGENTO_WEB_SERVER_CONF
   - run:
       name: Copy Magento 2 web server configuration file
       command: sudo cp magento2.conf /etc/apache2/sites-available/ && sudo a2ensite magento2.conf

--- a/src/commands/install_mariadb_and_setup_webserver.yml
+++ b/src/commands/install_mariadb_and_setup_webserver.yml
@@ -4,7 +4,7 @@ description: >
 steps:
   - run:
       name: Install mariadb-client
-      command: sudo apt-get install --allow-unauthenticated -qq -y mariadb-client
+      command: sudo apt-get install --allow-unauthenticated -y mariadb-client
   - run:
       name: Add magento2.dev to hosts file
       command: echo 127.0.0.1 magento2.dev | sudo tee -a /etc/hosts

--- a/src/commands/magento_compile_and_setup_upgrade.yml
+++ b/src/commands/magento_compile_and_setup_upgrade.yml
@@ -8,7 +8,7 @@ parameters:
 steps:
   - run:
       name: Run Magento Setup Upgrade
-      command: cd $MAGENTO_PATH && bin/magento setup:upgrade -q
+      command: cd $MAGENTO_PATH && bin/magento setup:upgrade
   - run:
       name: Run Magento DI Compile
       command: cd $MAGENTO_PATH && bin/magento setup:di:compile -q

--- a/src/commands/magento_compile_and_setup_upgrade.yml
+++ b/src/commands/magento_compile_and_setup_upgrade.yml
@@ -1,19 +1,26 @@
 description: >
   Setup upgrade and compile Magento
 
+parameters:
+  disable_cache:
+    type: boolean
+    default: true
 steps:
-  - run:
-      name: Run Magento DI Compile
-      command: cd $MAGENTO_PATH && bin/magento setup:di:compile -q
   - run:
       name: Run Magento Setup Upgrade
       command: cd $MAGENTO_PATH && bin/magento setup:upgrade -q
+  - run:
+      name: Run Magento DI Compile
+      command: cd $MAGENTO_PATH && bin/magento setup:di:compile -q
   - run:
       name: Set write permissions on var directory
       command: chmod -R 777 $MAGENTO_PATH/var
   - run:
       name: Run Magento Cache Flush
       command: $MAGENTO_PATH/bin/magento cache:flush -q
-  - run:
-      name: Disable Magento's cache
-      command: $MAGENTO_PATH/bin/magento cache:disable -q
+  - when:
+      condition: << parameters.disable_cache >>
+      steps:
+        - run:
+            name: Disable Magento's cache
+            command: $MAGENTO_PATH/bin/magento cache:disable -q

--- a/src/commands/magento_compile_and_setup_upgrade.yml
+++ b/src/commands/magento_compile_and_setup_upgrade.yml
@@ -11,16 +11,16 @@ steps:
       command: cd $MAGENTO_PATH && bin/magento setup:upgrade
   - run:
       name: Run Magento DI Compile
-      command: cd $MAGENTO_PATH && bin/magento setup:di:compile -q
+      command: cd $MAGENTO_PATH && bin/magento setup:di:compile
   - run:
       name: Set write permissions on var directory
       command: chmod -R 777 $MAGENTO_PATH/var
   - run:
       name: Run Magento Cache Flush
-      command: $MAGENTO_PATH/bin/magento cache:flush -q
+      command: $MAGENTO_PATH/bin/magento cache:flush
   - when:
       condition: << parameters.disable_cache >>
       steps:
         - run:
             name: Disable Magento's cache
-            command: $MAGENTO_PATH/bin/magento cache:disable -q
+            command: $MAGENTO_PATH/bin/magento cache:disable

--- a/src/commands/run_php_cs.yml
+++ b/src/commands/run_php_cs.yml
@@ -1,16 +1,43 @@
 description: >
   Install PHPCS dependencies and run
 
+parameters:
+  phpcs_install_strategy:
+    type: enum
+    enum: ["composer-require", "create-project"]
+    default: "composer-require"
+  severity:
+    type: string
+    default: "$SNIFFER_SEVERITY"
+  ignore:
+    type: string
+    default: ".circleci/config.yml,*.xml"
+
 steps:
   - run:
       name: Check PHP version
       command: php -v
-  - run:
-      name: Composer require PHPCS and Magento coding standard
-      command: <<include(scripts/install_phpcs.sh)>>
-  - run:
-      name: Set installed config paths
-      command: <<include(scripts/set_phpcs_config_paths.sh)>>
+  - when:
+      condition:
+        equal: ["composer-require", << parameters.phpcs_install_strategy >>]
+      steps:
+        - run:
+            name: Composer require PHPCS and Magento coding standard
+            command: <<include(scripts/install_phpcs.sh)>>
+        - run:
+            name: Set installed config paths
+            command: <<include(scripts/set_phpcs_config_paths.sh)>>
+  - when:
+      condition:
+        equal: ["create-project", << parameters.phpcs_install_strategy >>]
+      steps:
+        - run:
+            name: Composer create-project magento-coding-standard
+            command: composer create-project --no-progress magento/magento-coding-standard "$HOME"/vendor
   - run:
       name: Run PHPCS
+      environment:
+        PARAM_INSTALL_STRATEGY: << parameters.phpcs_install_strategy >>
+        PARAM_SEVERITY: << parameters.severity >>
+        PARAM_IGNORE: << parameters.ignore >>
       command: <<include(scripts/run_phpcs.sh)>>

--- a/src/commands/run_php_unit_tests.yml
+++ b/src/commands/run_php_unit_tests.yml
@@ -12,7 +12,6 @@ parameters:
 steps:
   - run:
       name: Run unit tests
-      environment:
-        PARAM_COVERAGE: << parameters.coverage >>
-        PARAM_PHPUNIT_BIN: << parameters.phpunit_bin >>
-      command: <<include(scripts/run_php_unit_tests.sh)>>
+      command: |
+        chmod -R 777 "$MAGENTO_PATH"/var
+        << parameters.phpunit_bin >> -c "$MAGENTO_PATH"/dev/tests/unit/phpunit.xml << parameters.coverage >>

--- a/src/commands/run_php_unit_tests.yml
+++ b/src/commands/run_php_unit_tests.yml
@@ -5,10 +5,14 @@ parameters:
   coverage:
     type: string
     default: ""
+  phpunit_bin:
+    type: string
+    default: "$MAGENTO_PATH/phpunit-$PHP_UNIT_VERSION.phar"
 
 steps:
   - run:
       name: Run unit tests
       environment:
         PARAM_COVERAGE: << parameters.coverage >>
+        PARAM_PHPUNIT_BIN: << parameters.phpunit_bin >>
       command: <<include(scripts/run_php_unit_tests.sh)>>

--- a/src/scripts/config_php_exts.sh
+++ b/src/scripts/config_php_exts.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-sudo docker-php-ext-configure intl && sudo docker-php-ext-configure gd --with-png-dir=/usr/include --with-jpeg-dir=/usr/include
+GD_FLAGS=$(circleci env subst "${PARAM_GD_CONFIGURE_FLAGS}")
+sudo docker-php-ext-configure intl && sudo docker-php-ext-configure gd $GD_FLAGS

--- a/src/scripts/download_libsodium.sh
+++ b/src/scripts/download_libsodium.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-wget --quiet https://download.libsodium.org/libsodium/releases/libsodium-"$LIBSODIUM_VERSION".tar.gz
+wget https://download.libsodium.org/libsodium/releases/libsodium-"$LIBSODIUM_VERSION".tar.gz

--- a/src/scripts/ebiz_mage_backup.sh
+++ b/src/scripts/ebiz_mage_backup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PARAM=$(circleci env subst "${PARAM_VERSION}")
-wget --quiet https://ebizmartsbackup.s3.amazonaws.com/Magento"${PARAM}"-PreCompiled.tar.gz
+wget https://ebizmartsbackup.s3.amazonaws.com/Magento"${PARAM}"-PreCompiled.tar.gz

--- a/src/scripts/ebiz_mage_backup_nosd.sh
+++ b/src/scripts/ebiz_mage_backup_nosd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PARAM=$(circleci env subst "${PARAM_VERSION}")
-wget --quiet https://ebizmartsbackup.s3.amazonaws.com/Magento"${PARAM}"-PreCompiled-NoSampleData.tar.gz
+wget https://ebizmartsbackup.s3.amazonaws.com/Magento"${PARAM}"-PreCompiled-NoSampleData.tar.gz

--- a/src/scripts/install_php_exts.sh
+++ b/src/scripts/install_php_exts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PARAM=$(circleci env subst "${PARAM_EXTENSIONS_TO_INSTALL}")
-sudo docker-php-ext-install $PARAM
+sudo -E docker-php-ext-install $PARAM

--- a/src/scripts/install_php_exts.sh
+++ b/src/scripts/install_php_exts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PARAM=$(circleci env subst "${PARAM_EXTENSIONS_TO_INSTALL}")
-sudo docker-php-ext-install "$PARAM"
+sudo docker-php-ext-install $PARAM

--- a/src/scripts/install_sys_libs.sh
+++ b/src/scripts/install_sys_libs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PARAM=$(circleci env subst "${PARAM_LIBRARIES_TO_INSTALL}")
-sudo apt-get install -qq -y g++ $PARAM
+sudo apt-get install -y g++ $PARAM

--- a/src/scripts/install_sys_libs.sh
+++ b/src/scripts/install_sys_libs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PARAM=$(circleci env subst "${PARAM_LIBRARIES_TO_INSTALL}")
-sudo apt-get install -qq -y g++ "$PARAM"
+sudo apt-get install -qq -y g++ $PARAM

--- a/src/scripts/reinstall_libsodium.sh
+++ b/src/scripts/reinstall_libsodium.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 sudo rm -f /usr/local/etc/php/conf.d/*sodium.ini
 sudo rm -f /usr/local/lib/php/extensions/*/*sodium.so
-sudo apt-get remove -qq -y libsodium*
+sudo apt-get remove -y libsodium*
 sudo mkdir -p /tmp/libsodium
 wget https://github.com/jedisct1/libsodium/archive/"$LIBSODIUM_VERSION"-RELEASE.tar.gz
 sudo tar -xzf "$LIBSODIUM_VERSION"-RELEASE.tar.gz -C /tmp/libsodium
-cd /tmp/libsodium/libsodium-"$LIBSODIUM_VERSION"-RELEASE/ && sudo ./configure && sudo make --silent && sudo make --silent check && sudo make --silent install
+cd /tmp/libsodium/libsodium-"$LIBSODIUM_VERSION"-RELEASE/ && sudo ./configure && sudo make && sudo make check && sudo make install
 cd / && sudo rm -rf /tmp/libsodium
 sudo pecl install -o -f libsodium
 sudo docker-php-ext-enable sodium

--- a/src/scripts/reinstall_libsodium.sh
+++ b/src/scripts/reinstall_libsodium.sh
@@ -3,7 +3,7 @@ sudo rm -f /usr/local/etc/php/conf.d/*sodium.ini
 sudo rm -f /usr/local/lib/php/extensions/*/*sodium.so
 sudo apt-get remove -qq -y libsodium*
 sudo mkdir -p /tmp/libsodium
-wget --quiet https://github.com/jedisct1/libsodium/archive/"$LIBSODIUM_VERSION"-RELEASE.tar.gz
+wget https://github.com/jedisct1/libsodium/archive/"$LIBSODIUM_VERSION"-RELEASE.tar.gz
 sudo tar -xzf "$LIBSODIUM_VERSION"-RELEASE.tar.gz -C /tmp/libsodium
 cd /tmp/libsodium/libsodium-"$LIBSODIUM_VERSION"-RELEASE/ && sudo ./configure && sudo make --silent && sudo make --silent check && sudo make --silent install
 cd / && sudo rm -rf /tmp/libsodium

--- a/src/scripts/run_php_unit_tests.sh
+++ b/src/scripts/run_php_unit_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-PARAM=$(circleci env subst "${PARAM_COVERAGE}")
-"$MAGENTO_PATH"/phpunit-"$PHP_UNIT_VERSION".phar -c "$MAGENTO_PATH"/dev/tests/unit/phpunit.xml "$PARAM"
+COVERAGE=$(circleci env subst "${PARAM_COVERAGE}")
+PHPUNIT_BIN=$(circleci env subst "${PARAM_PHPUNIT_BIN}")
+$PHPUNIT_BIN -c "$MAGENTO_PATH"/dev/tests/unit/phpunit.xml $COVERAGE

--- a/src/scripts/run_php_unit_tests.sh
+++ b/src/scripts/run_php_unit_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 COVERAGE=$(circleci env subst "${PARAM_COVERAGE}")
 PHPUNIT_BIN=$(circleci env subst "${PARAM_PHPUNIT_BIN}")
+chmod -R 777 "$MAGENTO_PATH"/var
 $PHPUNIT_BIN -c "$MAGENTO_PATH"/dev/tests/unit/phpunit.xml $COVERAGE

--- a/src/scripts/run_phpcs.sh
+++ b/src/scripts/run_phpcs.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-vendor/bin/phpcs --standard=Magento2,PSR1,PSR2 "$MAGENTO_PATH"/app/code/Ebizmarts/* --extensions=php,phtml --warning-severity="$SNIFFER_SEVERITY" --ignore=".circleci/config.yml,*.xml"
+SEVERITY=$(circleci env subst "${PARAM_SEVERITY}")
+IGNORE=$(circleci env subst "${PARAM_IGNORE}")
+if [ "${PARAM_INSTALL_STRATEGY}" = "create-project" ]; then
+  PHPCS_BIN="$HOME/vendor/vendor/bin/phpcs"
+else
+  PHPCS_BIN="vendor/bin/phpcs"
+fi
+"$PHPCS_BIN" --standard=Magento2,PSR1,PSR2 "$MAGENTO_PATH"/app/code/Ebizmarts/* --extensions=php,phtml --warning-severity="$SEVERITY" --ignore="$IGNORE"


### PR DESCRIPTION
## Summary

Adds parameters needed to make the orb's `install_linux_dependencies`, `magento_compile_and_setup_upgrade`, `run_php_unit_tests` and `run_php_cs` commands usable from PHP 8 / Magento 2.4+ consumers, plus a batch of small correctness and verbosity fixes that were exposed when the ebizmarts/magento2-sage-pay-suite 1.4 / 1.48 / 1.1 branches actually exercised these commands end-to-end.

All new parameters default to existing behavior — no breaking changes for current consumers.

## Parameter additions

- `install_linux_dependencies`
  - `gd_configure_flags` — defaults to PHP 7.x `--with-png-dir=/usr/include --with-jpeg-dir=/usr/include`, can be overridden to PHP 8 `--with-jpeg --with-webp --with-freetype`.
  - `import_db` (bool, default `true`) — lets jobs that attach the workspace after `install_linux_dependencies` skip the trailing DB import step.

- `magento_compile_and_setup_upgrade`
  - `disable_cache` (bool, default `true`) — lets integration test jobs leave the cache enabled.
  - Reordered to run `setup:upgrade` before `setup:di:compile` (correct order for Magento 2.4+).

- `run_php_unit_tests`
  - `phpunit_bin` (default `\$MAGENTO_PATH/phpunit-\$PHP_UNIT_VERSION.phar`) — consumers can pass `php \$MAGENTO_PATH/vendor/phpunit/phpunit/phpunit` for composer-vendored PHPUnit.
  - `chmod -R 777 \$MAGENTO_PATH/var` folded into the command body so consumers don't need a separate prelude step.
  - Substitution moved from `circleci env subst` to direct orb-render-time interpolation, matching the original inline form (the env-subst path was producing `unknown flag` errors on the `--coverage-text` arg in certain images).

- `run_php_cs`
  - `phpcs_install_strategy: composer-require | create-project` (enum, default `composer-require`) — lets consumers that already use `composer create-project magento/magento-coding-standard vendor` (binary at `~/vendor/vendor/bin/phpcs`) call the orb directly.
  - `severity` (default `\$SNIFFER_SEVERITY`)
  - `ignore` (default `.circleci/config.yml,*.xml`)

## Correctness fixes

- `install_sys_libs.sh` / `install_php_exts.sh`: unquoted `\$PARAM` so the shell word-splits the package list. Previously `apt-get install -qq -y g++ \"\$PARAM\"` passed the whole space-separated list as a single argument and apt aborted with `Unable to locate package <list>`.
- `install_linux_dependencies`: inlined the gd configure command instead of routing through `circleci env subst`; the env-subst path silently preserved quoting and `docker-php-ext-configure gd` rejected the flags with `unknown flag: --with-jpeg --with-webp --with-freetype`.
- `install_php_exts.sh`: switched to `sudo -E docker-php-ext-install \$PARAM` so `PHP_INI_DIR` is preserved across the sudo boundary — without `-E` the trailing `docker-php-ext-enable` step tried to create `/conf.d/docker-php-ext-bcmath.ini` and failed with `Directory nonexistent`.

## Verbosity changes

- Dropped `-q` from every `bin/magento` invocation in `magento_compile_and_setup_upgrade` (`setup:upgrade`, `setup:di:compile`, `cache:flush`, `cache:disable`) so Magento errors actually surface in CI logs.
- Dropped `--quiet` from every `wget` call across commands and scripts (`download_tools`, `install_linux_dependencies`, `install_mariadb_and_setup_webserver`, `ebiz_mage_backup`, `ebiz_mage_backup_nosd`, `download_libsodium`, `reinstall_libsodium`).
- Dropped `-qq` from every `apt-get` call (`install_linux_dependencies`, `install_sys_libs.sh`, `install_mariadb_and_setup_webserver`, `reinstall_libsodium`).
- Dropped `--silent` from the libsodium `make` chain.

## Test plan

- [x] Dev release `@dev:refactor-php8-gd-flags` was published and exercised end-to-end by the ebizmarts/magento2-sage-pay-suite 1.4 / 1.48 / 1.1 refactor branches:
  - PHP 81 Compile and API test ✅
  - PHP 81 / 82 Unit Tests + coverage variants ✅
  - PHP 81 / 82 Integration Tests ✅
  - PHP 81 Code Sniffer (create-project strategy) ✅
  - PHP 70 / 56 Code Sniffer (composer-require strategy) ✅
- [ ] After merge, tag `v1.2.0` to trigger the test-deploy pipeline's `orb-tools/publish` step.
- [ ] Bump consumer configs (`refactor-circleci_1.4-develop_useOrbMore`, `refactor-circleci_1.48-develop_useOrbMore`, `refactor-circleci_1.1-develop_useOrbMore`) from `@dev:refactor-php8-gd-flags` to `@1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)