### PR TITLE
download_tools: checkout module over HTTPS token instead of SSH deploy key

### DIFF
--- a/src/commands/download_tools.yml
+++ b/src/commands/download_tools.yml
@@ -28,8 +28,13 @@ steps:
   - run:
       name: Set bin/magento as executable
       command: chmod +x bin/magento
-  - checkout:
-      path: app/code/Ebizmarts/SagePaySuite
+  - run:
+      name: Checkout module source over HTTPS (no SSH deploy key)
+      command: |
+        git clone "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" app/code/Ebizmarts/SagePaySuite
+        git -C app/code/Ebizmarts/SagePaySuite checkout --force "$CIRCLE_SHA1"
+        # scrub the token so it is not persisted into the workspace .git/config
+        git -C app/code/Ebizmarts/SagePaySuite remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
   - run:
       name: Create folder for Opayo
       command: <<include(scripts/create_opayo_folder.sh)>>


### PR DESCRIPTION
## What

Replaces the built-in `checkout` step in the `download_tools` command with an HTTPS clone that authenticates via `GITHUB_USER` / `GITHUB_TOKEN`, instead of the project's SSH checkout (deploy) key.

## Why

The `checkout` step authenticates to GitHub over SSH using the project's deploy key. On repos where that deploy key isn't installed on the GitHub side (e.g. `magento2-sage-pay-suite-formcrypt`), checkout fails with `Permission denied (publickey)`. Cloning over HTTPS with a token — the same mechanism already used for the sibling-module clones — removes that per-project deploy-key dependency.

## Behaviour change (please note)

Consumers of `download_tools` must now have `GITHUB_USER` and `GITHUB_TOKEN` set as project env vars. Modules that already use these for sibling-repo clones are unaffected; any that relied solely on the SSH deploy key will need them added.

## Details

- Generic across consumers: uses `CIRCLE_PROJECT_USERNAME` / `CIRCLE_PROJECT_REPONAME`, so it keeps working for every module that calls `download_tools`.
- Faithful to `checkout`: clones then checks out the exact triggering commit `CIRCLE_SHA1`.
- Scrubs the token from the cloned repo's `.git/config` afterward, since the workspace is `persist_to_workspace`'d to downstream jobs.
- No `--filter=blob:none`, so the manual clone doesn't break on the older `circleci/php:7.x` images.

Validated with `circleci orb validate`/`pack` and exercised via a `@dev:https-checkout` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)